### PR TITLE
Request to add entity classes to FGD

### DIFF
--- a/gamemodes/extremefootballthrowdown/extremefootballthrowdown.fgd
+++ b/gamemodes/extremefootballthrowdown/extremefootballthrowdown.fgd
@@ -51,6 +51,14 @@
 [
 ]
 
+@PointClass base(Targetname) studio("models/props_docks/dock01_pole01a_128.mdl") color( 255 255 255 )   = prop_carry_bigpole : "EFT: Spawns a Big Pole."
+[
+]
+
+@PointClass base(Targetname) studio("models/props_junk/garbage_glassbottle001a.mdl") color( 255 255 255 )   = prop_carry_boozebottle : "EFT: Spawns a Booze Bottle."
+[
+]
+
 @PointClass base(Targetname) studio("models/props_vehicles/car002a.mdl") color( 255 255 255 )   = prop_carry_car : "EFT: Spawns a Clown Car."
 [
 ]
@@ -60,6 +68,14 @@
 ]
 
 @PointClass base(Targetname) studio("models/weapons/w_rocket_launcher.mdl") color( 255 255 255 )   = prop_carry_melondriver : "EFT: Spawns a Melon Driver."
+[
+]
+
+@PointClass base(Targetname) studio("models/props_c17/trappropeller_engine.mdl") color( 255 255 255 )   = prop_carry_mowertrap : "EFT: Spawns a Mower Trap."
+[
+]
+
+@PointClass base(Targetname) studio("models/props_phx/amraam.mdl") color( 255 255 255 )   = prop_carry_tomahawk : "EFT: Spawns a Tomahawk Missle."
 [
 ]
 

--- a/gamemodes/extremefootballthrowdown/extremefootballthrowdown.fgd
+++ b/gamemodes/extremefootballthrowdown/extremefootballthrowdown.fgd
@@ -51,14 +51,6 @@
 [
 ]
 
-@PointClass base(Targetname) studio("models/props_docks/dock01_pole01a_128.mdl") color( 255 255 255 )   = prop_carry_bigpole : "EFT: Spawns a Big Pole."
-[
-]
-
-@PointClass base(Targetname) studio("models/props_junk/garbage_glassbottle001a.mdl") color( 255 255 255 )   = prop_carry_boozebottle : "EFT: Spawns a Booze Bottle."
-[
-]
-
 @PointClass base(Targetname) studio("models/props_vehicles/car002a.mdl") color( 255 255 255 )   = prop_carry_car : "EFT: Spawns a Clown Car."
 [
 ]
@@ -68,14 +60,6 @@
 ]
 
 @PointClass base(Targetname) studio("models/weapons/w_rocket_launcher.mdl") color( 255 255 255 )   = prop_carry_melondriver : "EFT: Spawns a Melon Driver."
-[
-]
-
-@PointClass base(Targetname) studio("models/props_c17/trappropeller_engine.mdl") color( 255 255 255 )   = prop_carry_mowertrap : "EFT: Spawns a Mower Trap."
-[
-]
-
-@PointClass base(Targetname) studio("models/props_phx/amraam.mdl") color( 255 255 255 )   = prop_carry_tomahawk : "EFT: Spawns a Tomahawk Missle."
 [
 ]
 


### PR DESCRIPTION
I noticed during mapping that the prop_carry_ point entities were missing for big pole, booze bottle, mower trap, and tomahawk missile, so I want to have these included in the FGD. I do not know if you excluded these on purpose, but let me know if you did.