### PR TITLE
Prevented extreme speeds from carrying over on jump

### DIFF
--- a/gamemodes/extremefootballthrowdown/gamemode/shared.lua
+++ b/gamemodes/extremefootballthrowdown/gamemode/shared.lua
@@ -393,6 +393,14 @@ function GM:OnPlayerHitGround(pl, inwater, hitfloater, speed)
 		end
 	end
 
+	local initvel = pl:GetVelocity()
+	local plspeed = math.sqrt(initvel.x ^ 2 + initvel.y ^ 2)
+	if (plspeed > 375) then
+		initvel.z=0
+		div = plspeed / 375
+		pl:SetVelocity( -initvel/div )
+	end
+
 	return true
 end
 


### PR DESCRIPTION
Speed is now greatly curbed, when landing on a fast jump. For the majority of cases it doesn't slow the player to the stop and still keeps the flow of the game moving.