### PR TITLE
Fix for deathnotices

### DIFF
--- a/gamemodes/extremefootballthrowdown/entities/entities/prop_ball/init.lua
+++ b/gamemodes/extremefootballthrowdown/entities/entities/prop_ball/init.lua
@@ -228,7 +228,7 @@ function ENT:Touch(ent)
 	if ent:IsPlayer() and not self:GetCarrier():IsValid() and ent:Alive() and not ent:IsCarrying() and not GAMEMODE:IsWarmUp()
 	and ent:CallStateFunction("CanPickup", self) and (self:GetLastCarrier() ~= ent or CurTime() > (self.m_PickupImmunity or 0))
 	and (ent:Team() ~= self:GetLastCarrierTeam() or CurTime() > (self.m_TeamPickupImmunity or 0)) then
-		if team.HasPlayers(ent:Team() == TEAM_RED and TEAM_BLUE or TEAM_RED) then
+		if team.HasPlayers(ent:Team() == TEAM_RED and TEAM_BLUE or TEAM_RED) or game.MaxPlayers() == 1 then
 			self:SetCarrier(ent)
 			ent:AddFrags(5)
 
@@ -266,10 +266,10 @@ function ENT:Drop(throwforce, suicide)
 		end
 
 		if throwforce then
-			GAMEMODE:BroadcastAction(carrier:Name(), "threw the ball!")
+			GAMEMODE:BroadcastAction(carrier:Name(), "threw the ball!", carrier:Team())
 			self.m_TeamPickupImmunity = CurTime() + 0.25
 		else
-			GAMEMODE:BroadcastAction(carrier:Name(), "dropped the ball!")
+			GAMEMODE:BroadcastAction(carrier:Name(), "dropped the ball!", carrier:Team())
 		end
 	end
 

--- a/gamemodes/extremefootballthrowdown/entities/entities/prop_ball/shared.lua
+++ b/gamemodes/extremefootballthrowdown/entities/entities/prop_ball/shared.lua
@@ -232,7 +232,7 @@ function ENT:SetCarrier(ent)
 		if phys:IsValid() then phys:EnableMotion(false) end
 		self:SetCollisionGroup(COLLISION_GROUP_DEBRIS)
 
-		GAMEMODE:BroadcastAction(ent:Name(), "picked up the ball!")
+		GAMEMODE:BroadcastAction(ent:Name(), "picked up the ball!", entteam)
 
 		self:CallStateFunction("PickedUp", ent)
 

--- a/gamemodes/extremefootballthrowdown/gamemode/init.lua
+++ b/gamemodes/extremefootballthrowdown/gamemode/init.lua
@@ -671,11 +671,15 @@ function BroadcastLua(lua)
 	end
 end
 
-function GM:BroadcastAction(subject, action)
+function GM:BroadcastAction(subject, action, teamnum)
 	if type(subject) == "string" then
-		BroadcastLua(string.format("GAMEMODE:AddPlayerAction(%q, %q)", subject, action))
+		if teamnum then
+			BroadcastLua(string.format("GAMEMODE:AddTeamPlayerAction(%q, %q, %i)", subject, action, teamnum))
+		else
+			BroadcastLua(string.format("GAMEMODE:AddPlayerAction(%q, %q)", subject, action))
+		end
 	else
-		BroadcastLua(string.format("GAMEMODE:AddPlayerAction(Entity("..subject:EntIndex().."), %q)", action))
+		BroadcastLua(string.format("GAMEMODE:AddPlayerAction(Entity("..subject:EntIndex().."), %q )", action))
 	end
 end
 

--- a/gamemodes/fretta13/gamemode/cl_deathnotice.lua
+++ b/gamemodes/fretta13/gamemode/cl_deathnotice.lua
@@ -105,9 +105,9 @@ function GM:AddDeathNotice( attacker, team1, inflictor, victim, team2 )
 
 		local pnl = vgui.Create( "GameNotice", g_DeathNotify )
 
-		pnl:AddText( attacker or "", GAMEMODE:GetTeamNumColor(attackerTeam) )
+		pnl:AddText( attacker or "", GAMEMODE:GetTeamNumColor(team1) )
 		pnl:AddIcon( inflictor )
-		pnl:AddText( victim or "", GAMEMODE:GetTeamNumColor(victimTeam) )
+		pnl:AddText( victim or "", GAMEMODE:GetTeamNumColor(team2) )
 
 		g_DeathNotify:AddItem( pnl )
 

--- a/gamemodes/fretta13/gamemode/cl_deathnotice.lua
+++ b/gamemodes/fretta13/gamemode/cl_deathnotice.lua
@@ -1,5 +1,6 @@
 /*
 	Start of the death message stuff.
+	2024: Compatibility with base gamemode changes
 */
 
 include( 'vgui/vgui_gamenotice.lua' )
@@ -9,7 +10,7 @@ local function CreateDeathNotify()
 	local x, y = ScrW(), ScrH()
 
 	g_DeathNotify = vgui.Create( "DNotify" )
-	
+
 	g_DeathNotify:SetPos( 0, 25 )
 	g_DeathNotify:SetSize( x - ( 25 ), y )
 	g_DeathNotify:SetAlignment( 9 )
@@ -29,10 +30,10 @@ local function RecvPlayerKilledByPlayer( length )
 
 	if ( !IsValid( attacker ) ) then return end
 	if ( !IsValid( victim ) ) then return end
-	
-	GAMEMODE:AddDeathNotice( victim, inflictor, attacker )	
+
+	GAMEMODE:AddDeathNotice( attacker:Name(), attacker:Team(), inflictor, victim:Name(), victim:Team() )
 end
-	
+
 net.Receive( "PlayerKilledByPlayer", RecvPlayerKilledByPlayer )
 
 
@@ -42,10 +43,10 @@ local function RecvPlayerKilledSelf( length )
 
 	if ( !IsValid( victim ) ) then return end
 
-	GAMEMODE:AddPlayerAction( victim, GAMEMODE.SuicideString )
+	GAMEMODE:AddPlayerAction( victim:Name(), GAMEMODE.SuicideString )
 
 end
-	
+
 net.Receive( "PlayerKilledSelf", RecvPlayerKilledSelf )
 
 
@@ -53,28 +54,29 @@ local function RecvPlayerKilled( length )
 
 	local victim 	= net.ReadEntity()
 	local inflictor	= net.ReadString()
-	local attacker 	= "#" .. net.ReadString()
+	local attacker 	= net.ReadString()
 
+	print("RecvPlayerKilled")
 	if ( !IsValid( victim ) ) then return end
-			
-	GAMEMODE:AddDeathNotice( victim, inflictor, attacker )
+
+	GAMEMODE:AddDeathNotice( "#" .. attacker, -1, inflictor, victim:Name(), victim:Team() )
 
 end
-	
+
 net.Receive( "PlayerKilled", RecvPlayerKilled )
 
 local function RecvPlayerKilledNPC( length )
 
-	local victim 	= "#" .. net.ReadString()
+	local victim 	= net.ReadString()
 	local inflictor	= net.ReadString()
 	local attacker 	= net.ReadEntity()
 
 	if ( !IsValid( attacker ) ) then return end
-			
-	GAMEMODE:AddDeathNotice( victim, inflictor, attacker )
+
+	GAMEMODE:AddDeathNotice( attacker, attacker:Team(), inflictor, "#" .. victim, 0 )
 
 end
-	
+
 net.Receive( "PlayerKilledNPC", RecvPlayerKilledNPC )
 
 
@@ -83,8 +85,8 @@ local function RecvNPCKilledNPC( length )
 	local victim 	= "#" .. net.ReadString()
 	local inflictor	= net.ReadString()
 	local attacker 	= "#" .. net.ReadString()
-		
-	GAMEMODE:AddDeathNotice( victim, inflictor, attacker )
+
+	GAMEMODE:AddDeathNotice( attacker, -1, inflictor, victim, -1 )
 
 end
 
@@ -92,25 +94,32 @@ net.Receive( "NPCKilledNPC", RecvNPCKilledNPC )
 
 
 /*---------------------------------------------------------
-   Name: gamemode:AddDeathNotice( Victim, Weapon, Attacker )
+   Name: gamemode:AddDeathNotice( Attacker, team1, Inflictor, Victim, team2, flags )
    Desc: Adds an death notice entry
 ---------------------------------------------------------*/
-function GM:AddDeathNotice( victim, inflictor, attacker )
+function GM:AddDeathNotice( attacker, team1, inflictor, victim, team2 )
 
 	if ( !IsValid( g_DeathNotify ) ) then return end
-
-	local pnl = vgui.Create( "GameNotice", g_DeathNotify )
 	
-	pnl:AddText( attacker )
-	pnl:AddIcon( inflictor )
-	pnl:AddText( victim )
-	
-	g_DeathNotify:AddItem( pnl )
+	if inflictor and inflictor != "suicide" then
 
+		local pnl = vgui.Create( "GameNotice", g_DeathNotify )
+
+		pnl:AddText( attacker or "", GAMEMODE:GetTeamNumColor(attackerTeam) )
+		pnl:AddIcon( inflictor )
+		pnl:AddText( victim or "", GAMEMODE:GetTeamNumColor(victimTeam) )
+
+		g_DeathNotify:AddItem( pnl )
+
+	else
+		--We need to handle suicides within this due to basegame deprecation
+		
+		GAMEMODE:AddTeamPlayerAction( victim, GAMEMODE.SuicideString, team2 )
+	end
 end
 
 function GM:AddPlayerAction( ... )
-	
+
 	if ( !IsValid( g_DeathNotify ) ) then return end
 
 	local pnl = vgui.Create( "GameNotice", g_DeathNotify )
@@ -118,10 +127,26 @@ function GM:AddPlayerAction( ... )
 	for k, v in ipairs({...}) do
 		pnl:AddText( v )
 	end
-	
+
 	// The rest of the arguments should be re-thought.
 	// Just create the notify and add them instead of trying to fit everything into this function!???
-	
+
 	g_DeathNotify:AddItem( pnl )
-	
+
+end
+
+function GM:AddTeamPlayerAction( subject, action, teamnum )
+
+	if ( !IsValid( g_DeathNotify ) ) then return end
+
+	local pnl = vgui.Create( "GameNotice", g_DeathNotify )
+
+	pnl:AddText( subject, GAMEMODE:GetTeamNumColor(teamnum) )
+	pnl:AddText( action )
+
+	// The rest of the arguments should be re-thought.
+	// Just create the notify and add them instead of trying to fit everything into this function!???
+
+	g_DeathNotify:AddItem( pnl )
+
 end


### PR DESCRIPTION
Fixes the death notices to work with GMOD's 2024 GM:AddDeathNotice changes.

- Will display the correct names and colors for kills and ball interactions
- New function GM:AddTeamPlayerAction() can be used to display colored names, GM:BroadcastAction() has been updated to support a third field for team number
- Suicides will not produce errors
- Most of the RecvPlayerKilled functions should be deprecated, I do not know where they are needed. I do not know if they even get run? I couldn't get them to print anything I've updated them to the current specifications regardless.
- You can also pick up the ball in singleplayer, this is just to make testing easier.